### PR TITLE
Add openSUSE OS projects

### DIFF
--- a/data/projects/development/zypper.yaml
+++ b/data/projects/development/zypper.yaml
@@ -1,0 +1,6 @@
+---
+name: Zypper
+repository: https://github.com/openSUSE/zypper
+twitter:
+website: https://en.opensuse.org/Portal:Zypper
+description: World's most powerful command line package manager.

--- a/data/projects/operating-systems/kubic.yaml
+++ b/data/projects/operating-systems/kubic.yaml
@@ -1,0 +1,6 @@
+---
+name: Kubic
+repository: https://github.com/kubic-project
+twitter:
+website: https://kubic.opensuse.org/
+description: Certified Kubernetes distribution & container-related technologies built by the openSUSE community.

--- a/data/projects/operating-systems/leap.yaml
+++ b/data/projects/operating-systems/leap.yaml
@@ -1,0 +1,6 @@
+---
+name: openSUSE Leap
+repository: https://build.opensuse.org/project/show/openSUSE:Factory
+twitter: https://twitter.com/openSUSE
+website: https://www.opensuse.org/#Leap
+description: openSUSE's regular-release, Linux distribution.

--- a/data/projects/operating-systems/microos.yaml
+++ b/data/projects/operating-systems/microos.yaml
@@ -1,0 +1,6 @@
+---
+name: openSUSE MicroOS
+repository: https://github.com/kubic-project
+twitter:
+website: https://microos.opensuse.org/
+description: Micro Service OS built by the openSUSE community.

--- a/data/projects/operating-systems/tumbleweed.yaml
+++ b/data/projects/operating-systems/tumbleweed.yaml
@@ -1,0 +1,6 @@
+---
+name: openSUSE Tumbleweed
+repository: https://build.opensuse.org/project/show/openSUSE:Factory
+twitter: https://twitter.com/openSUSE
+website: https://www.opensuse.org/#Tumbleweed
+description: openSUSE's rolling-release, Linux distribution.


### PR DESCRIPTION
This PR provides a baseline for openSUSE OS-related projects. It does not provide any logos due to due personal lack of knowledge into [openSUSE branding](https://en.opensuse.org/openSUSE:Artwork_brand). However, I believe this PR is a necessary start for adding the projects.

**Note:** all descriptions were taken directly from project sites and repositories.