### PR TITLE
Fix wording from "create" to "contribute"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the source repo for the [SUSE Projects](https://suse-projects.github.io) page.
 
-This page is a compilation of open source software that SUSE has created.
+This page is a compilation of open source software that SUSE contributes to.
 
 ## Contributing
 


### PR DESCRIPTION
So that projects where SUSE is not the sole creator are not
excluded.