### PR TITLE
Fix wording "Github" to "sources"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 baseURL: https://suse-projects.github.io
 languageCode: en-us
-title: SUSE sources
+title: SUSE Open Source Projects
 disableKinds:
 - taxonomy
 - term

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 baseURL: https://suse-projects.github.io
 languageCode: en-us
-title: SUSE On GitHub
+title: SUSE sources
 disableKinds:
 - taxonomy
 - term


### PR DESCRIPTION
So projects, that are hosted somehwere else besides Github, are not excluded.