### PR TITLE
Add the vhostmd project

### DIFF
--- a/data/projects/infrastructure/vhostmd.yaml
+++ b/data/projects/infrastructure/vhostmd.yaml
@@ -1,0 +1,6 @@
+---
+name: vhostmd
+repository: https://github.com/vhostmd/vhostmd
+twitter:
+website:
+description: Hypervisor service providing metrics/diagnostics information from hosted virtual machines.


### PR DESCRIPTION
vhostmd is a project created by the virtualization team around 2008.
It has bounced around several SCM over the over the years but has
been hosted at github for quite some time now.

vhostmd is provided in openSUSE/SLE and is available in several distros
and products such as oVirt. It is also used extensively at SAP. vhostmd
sees the occassional contribution from RedHat and SAP.