### PR TITLE
Add Jangouts to the list of projects

### DIFF
--- a/data/projects/infrastructure/jangouts.yaml
+++ b/data/projects/infrastructure/jangouts.yaml
@@ -1,0 +1,6 @@
+---
+name: Jangouts
+repository: https://github.com/jangouts/jangouts
+twitter:
+website: https://github.com/jangouts/jangouts#readme
+description: Self-hosted videoconferencing solution supporting video, chat and screen sharing.


### PR DESCRIPTION
Add Jangouts to the list of projects. This is a tool developed in-house at SUSE that the YaST Team has been using as main communication mechanisms since 2015 (and has been used by other teams at SUSE as well).