### PR TITLE
adding jeos-firstboot

### DIFF
--- a/data/projects/operating-systems/jeos-firstboot.yaml
+++ b/data/projects/operating-systems/jeos-firstboot.yaml
@@ -1,0 +1,6 @@
+name: jeos-firstboot
+repository: https://github.com/openSUSE/jeos-firstboot
+twitter:
+website:
+description: Lightweight and customisable firstboot wizard that allows to set basic system settings
+during and after the first boot of an image.

--- a/data/projects/operating-systems/jeos-firstboot.yaml
+++ b/data/projects/operating-systems/jeos-firstboot.yaml
@@ -1,6 +1,6 @@
 name: jeos-firstboot
 repository: https://github.com/openSUSE/jeos-firstboot
 twitter:
-website:
+website: https://github.com/openSUSE/jeos-firstboot#readme
 description: Lightweight and customisable firstboot wizard that allows to set basic system settings
 during and after the first boot of an image.


### PR DESCRIPTION
Hi, I would like to add jeos-firstboot.
It is used by the Just Enough Operating System images of openSUSE Leap/Tumbleweed + SLES + SLES for RPi

Regards,