### PR TITLE
Add YaST and LibYUI to the list of projects

### DIFF
--- a/data/projects/development/libyui.yaml
+++ b/data/projects/development/libyui.yaml
@@ -1,0 +1,6 @@
+---
+name: LibYUI
+repository: https://github.com/libyui/libyui
+twitter:
+website:
+description: Widget abstraction library providing graphical and text-based front-ends

--- a/data/projects/operations/yast.yaml
+++ b/data/projects/operations/yast.yaml
@@ -1,0 +1,6 @@
+---
+name: YaST
+repository: https://github.com/yast/
+twitter:
+website: https://yast.opensuse.org/
+description: Installation and configuration tool for openSUSE and SUSE distributions


### PR DESCRIPTION
The list is really nice, but YaSTees would love to see YaST and LibYUI in the list too :-) For YaST, we do not have a single repository, so I have linked the organization page in GitHub.

Thanks!