### PR TITLE
Fixing ComplianceAsCode-content repo url. The old one was giving 404

### DIFF
--- a/data/projects/security/complianceascode.yaml
+++ b/data/projects/security/complianceascode.yaml
@@ -1,6 +1,6 @@
 ---
 name: ComplianceAsCode
-repository: https://github.com/SUSE/ComplianceAsCodeContent/
+repository: https://github.com/openSUSE/ComplianceAsCode-content
 twitter:
 website:
 description: Creation of security policy content for various platforms.


### PR DESCRIPTION
Fixing ComplianceAsCode-content repo url. The old one was giving 404 error...